### PR TITLE
create_config.sh: Support custom log level and disabling access log

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ $ docker run -d \
 
 > Reloads Nginx configuration each month on the 15th over Docker without restarting Nginx! In order to achieve high availability!
 
-# Basic User Authentification
+# Basic User Authentication
 
 You can password protect any reverse proxy. Additionally you can specify an arbitrary amount of users.
 
@@ -421,6 +421,21 @@ docker run -d \
 ~~~~
 
 > Access to http://localhost are both enabled for user `admin1` and user `admin2`.
+
+# Changing Log Level and disabling the Access Log
+
+If you find the access log output too verbose, it can be disabled.
+
+~~~~
+$ docker run -d \
+    -p 80:80 \
+    --name nginx \
+    -e "SERVER1REVERSE_PROXY_LOCATION1=/" \
+    -e "SERVER1REVERSE_PROXY_PASS1=http://www.heise.de" \
+    -e "LOG_LEVEL=warn" \
+    -e "DISABLE_ACCESS_LOG=true" \
+    blacklabelops/nginx
+~~~~
 
 # Build The Image
 

--- a/imagescripts/create_config.sh
+++ b/imagescripts/create_config.sh
@@ -5,9 +5,18 @@ set -o errexit
 NAMESERVER=$(cat /etc/resolv.conf | grep "nameserver" | tail -1 | awk '{print $2}' | tr '\n' ' ')
 LOG_FORMAT='$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"'
 
+if [ -z "${LOG_LEVEL}" ]; then
+    LOG_LEVEL=info
+fi
+
+ACCESS_LOG=/dev/stdout
+if [ "${DISABLE_ACCESS_LOG}" == 'true' ]; then
+    ACCESS_LOG=off
+fi
+
 cat > ${NGINX_DIRECTORY}/nginx.conf <<_EOF_
 worker_processes auto;
-error_log /dev/stdout info;
+error_log /dev/stdout ${LOG_LEVEL};
 
 events {
     worker_connections 1024;
@@ -16,7 +25,7 @@ events {
 http {
     log_format  main  '${LOG_FORMAT}';
 
-    access_log /dev/stdout;
+    access_log ${ACCESS_LOG};
 
     sendfile              on;
     tcp_nopush            on;


### PR DESCRIPTION
For some services the default info log level is very verbose and can obscure
warning messages from other services.

Signed-off-by: Konrad Scherer <kmscherer@gmail.com>