### PR TITLE
Disable IPv6 & custom ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ $ docker run -d \
 
 If you want to pass requests to the Docker host, you need to connect the NGINX container directly to the host networking stack.
 
-Unfortunately, if your Docker host is running on a QNAP NAS, port 80 and 443 are already used by the embedded web server. You can use custom ports in such a case.
+Unfortunately, if your Docker host is running on a QNAP NAS, port 80 and 443 (as well as 8080 and 8081) are already used by the embedded web server. You can use custom ports in such a case.
 
 ~~~~
 $ docker run -d \

--- a/README.md
+++ b/README.md
@@ -437,6 +437,39 @@ $ docker run -d \
     blacklabelops/nginx
 ~~~~
 
+# Use IPv6
+
+You can use IPv6 instead of IPv4 (default).
+
+~~~~
+$ docker run -d \
+    -p 80:80 \
+    --name nginx \
+    -e "NGINX_USE_IPV6"="true"
+    -e "SERVER1REVERSE_PROXY_LOCATION1=/" \
+    -e "SERVER1REVERSE_PROXY_PASS1=http://www.heise.de" \
+    blacklabelops/nginx
+~~~~
+
+# Use custom HTTP or HTTPS ports
+
+If you want to pass requests to the Docker host, you need to connect the NGINX container directly to the host networking stack.
+
+Unfortunately, if your Docker host is running on a QNAP NAS, port 80 and 443 are already used by the embedded web server. You can use custom ports in such a case.
+
+~~~~
+$ docker run -d \
+    --net=host \
+    --name nginx \
+    -e "NGINX_HTTP_PORT"="9000" \
+    -e "NGINX_HTTPS_PORT"="9001" \
+    -e "SERVER1REVERSE_PROXY_LOCATION1=/" \
+    -e "SERVER1REVERSE_PROXY_PASS1=http://localhost:8080" \
+    blacklabelops/nginx
+~~~~
+
+> Note: If you use port forwarding on your router, you need to forward port 80 and 443 to port 9000 and 9001.
+
 # Build The Image
 
 The build process can take the following argument:

--- a/imagescripts/create_config.sh
+++ b/imagescripts/create_config.sh
@@ -2,7 +2,7 @@
 
 set -o errexit
 
-NAMESERVER=$(cat /etc/resolv.conf | grep "nameserver" | tail -1 | awk '{print $2}' | tr '\n' ' ')
+NAMESERVER=$(cat /etc/resolv.conf | grep "nameserver" | head -1 | awk '{print $2}' | tr '\n' ' ')
 LOG_FORMAT='$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" "$http_x_forwarded_for"'
 
 if [ -z "${LOG_LEVEL}" ]; then
@@ -19,19 +19,19 @@ worker_processes auto;
 error_log /dev/stdout ${LOG_LEVEL};
 
 events {
-    worker_connections 1024;
+  worker_connections 1024;
 }
 
 http {
-    log_format  main  '${LOG_FORMAT}';
+  log_format  main  '${LOG_FORMAT}';
 
-    access_log ${ACCESS_LOG};
+  access_log ${ACCESS_LOG};
 
-    sendfile              on;
-    tcp_nopush            on;
-    tcp_nodelay           on;
+  sendfile              on;
+  tcp_nopush            on;
+  tcp_nodelay           on;
 
-    resolver ${NAMESERVER} ipv6=off valid=30s;
+  resolver ${NAMESERVER} ipv6=off valid=30s;
 _EOF_
 
 nginx_upload_size='100m'
@@ -41,18 +41,17 @@ if [ -n "${NGINX_MAX_UPLOAD_SIZE}" ]; then
 fi
 
 cat >> ${NGINX_DIRECTORY}/nginx.conf <<_EOF_
-    client_max_body_size  ${nginx_upload_size};
+  client_max_body_size  ${nginx_upload_size};
 _EOF_
 
 cat >> ${NGINX_DIRECTORY}/nginx.conf <<_EOF_
-    keepalive_timeout     65;
-    types_hash_max_size   2048;
+  keepalive_timeout     65;
+  types_hash_max_size   2048;
 
-    # Load modular configuration files from the /etc/nginx/conf.d directory.
-    # See http://nginx.org/en/docs/ngx_core_module.html#include
-    # for more information.
-    include ${NGINX_DIRECTORY}/conf.d/*.conf;
-
+  # Load modular configuration files from the /etc/nginx/conf.d directory.
+  # See http://nginx.org/en/docs/ngx_core_module.html#include
+  # for more information.
+  include ${NGINX_DIRECTORY}/conf.d/*.conf;
 _EOF_
 
 if [ -n "${SERVER1REVERSE_PROXY_LOCATION1}" ]; then

--- a/imagescripts/custom_server.sh
+++ b/imagescripts/custom_server.sh
@@ -2,6 +2,22 @@
 
 set -o errexit
 
+nginx_use_ipv6="false"
+nginx_http_port="80"
+nginx_https_port="443"
+
+if [ -n "${NGINX_USE_IPV6}" ]; then
+  nginx_use_ipv6=${NGINX_USE_IPV6}
+fi
+
+if [ -n "${NGINX_HTTP_PORT}" ]; then
+  nginx_http_port=${NGINX_HTTP_PORT}
+fi
+
+if [ -n "${NGINX_HTTPS_PORT}" ]; then
+  nginx_https_port=${NGINX_HTTPS_PORT}
+fi
+
 for (( j=1; ; j++ ))
 do
   configFile=${NGINX_DIRECTORY}/conf.d/server${j}.conf
@@ -56,32 +72,49 @@ do
   NGINX_LETSENCRYPT_CERTIFICATES=${!VAR_LETSENCRYPT_CERTIFICATES}
 
   cat >> ${configFile} <<_EOF_
-    server {
+server {
 _EOF_
 
   if [ "${NGINX_HTTP_ENABLED}" = 'true' ]; then
     if [ "${NGINX_SERVER_NAME}" = '_' ]; then
-      cat >> ${configFile} <<_EOF_
-        listen       80 default_server;
-        listen       [::]:80 default_server;
+      if [ "${nginx_use_ipv6}" = 'true' ]; then
+        cat >> ${configFile} <<_EOF_
+  listen       [::]:${nginx_http_port} default_server;
 _EOF_
+      else
+        cat >> ${configFile} <<_EOF_
+  listen       ${nginx_http_port} default_server;
+_EOF_
+      fi
     else
-      cat >> ${configFile} <<_EOF_
-        listen       80;
-        listen       [::]:80;
+      if [ "${nginx_use_ipv6}" = 'true' ]; then
+        cat >> ${configFile} <<_EOF_
+  listen       [::]:${nginx_http_port};
 _EOF_
+      else
+        cat >> ${configFile} <<_EOF_
+  listen       ${nginx_http_port};
+_EOF_
+      fi
     fi
   fi
 
   if [ "${NGINX_HTTPS_ENABLED}" = 'true' ]; then
-    cat >> ${configFile} <<_EOF_
-        listen              443 ssl;
-        keepalive_timeout   0;
+    if [ "${nginx_use_ipv6}" = 'true' ]; then
+      cat >> ${configFile} <<_EOF_
+  listen              [::]:${nginx_https_port} ipv6only=on ssl;
+  keepalive_timeout   0;
 _EOF_
+    else
+      cat >> ${configFile} <<_EOF_
+  listen              ${nginx_https_port} ssl;
+  keepalive_timeout   0;
+_EOF_
+    fi
   fi
 
   cat >> ${configFile} <<_EOF_
-        server_name  ${NGINX_SERVER_NAME};
+  server_name         ${NGINX_SERVER_NAME};
 _EOF_
 
   if [ -n "$NGINX_CERTIFICATE_DNAME" ] && [ "${NGINX_HTTPS_ENABLED}" = 'true' ]; then
@@ -89,28 +122,28 @@ _EOF_
       openssl req -subj "${NGINX_CERTIFICATE_DNAME}" -new -newkey rsa:4096 -days 365 -nodes -x509 -keyout ${NGINX_DIRECTORY}/keys/server.key -out ${NGINX_DIRECTORY}/keys/server.crt
     fi
     cat >> ${configFile} <<_EOF_
-        ssl_certificate     ${NGINX_CERTIFICATE_FILE};
-        ssl_certificate_key ${NGINX_CERTIFICATE_KEY};
+  ssl_certificate         ${NGINX_CERTIFICATE_FILE};
+  ssl_certificate_key     ${NGINX_CERTIFICATE_KEY};
 _EOF_
   fi
 
   if [ ! -n "$NGINX_CERTIFICATE_DNAME" ] && [ "${NGINX_HTTPS_ENABLED}" = 'true' ]; then
     cat >> ${configFile} <<_EOF_
-        ssl_certificate     ${NGINX_CERTIFICATE_FILE};
-        ssl_certificate_key ${NGINX_CERTIFICATE_KEY};
+  ssl_certificate         ${NGINX_CERTIFICATE_FILE};
+  ssl_certificate_key     ${NGINX_CERTIFICATE_KEY};
 _EOF_
   fi
 
   if [ -n "$NGINX_CERTIFICATE_TRUSTED" ]; then
     cat >> ${configFile} <<_EOF_
-        ssl_trusted_certificate ${NGINX_CERTIFICATE_TRUSTED};
+  ssl_trusted_certificate ${NGINX_CERTIFICATE_TRUSTED};
 _EOF_
   fi
 
   if [ -n "$NGINX_CERTIFICATE_DNAME" ] && [ "${NGINX_HTTPS_ENABLED}" = 'true' ]; then
     cat >> ${configFile} <<_EOF_
-        ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers         HIGH:!aNULL:!MD5;
+  ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers         HIGH:!aNULL:!MD5;
 _EOF_
   fi
 
@@ -119,32 +152,32 @@ _EOF_
       openssl dhparam -out /home/nginx/dhparam.pem 2048
     fi
     cat >> ${configFile} <<_EOF_
-        ssl_session_timeout 1d;
-        ssl_session_cache shared:SSL:50m;
+  ssl_session_timeout 1d;
+  ssl_session_cache shared:SSL:50m;
 
-        # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
-        # Generate with:
-        #   openssl dhparam -out /etc/nginx/dhparam.pem 2048
-        ssl_dhparam /home/nginx/dhparam.pem;
+  # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+  # Generate with:
+  #   openssl dhparam -out /etc/nginx/dhparam.pem 2048
+  ssl_dhparam /home/nginx/dhparam.pem;
 
-        # What Mozilla calls "Intermediate configuration"
-        # Copied from https://mozilla.github.io/server-side-tls/ssl-config-generator/
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
-        ssl_prefer_server_ciphers on;
+  # What Mozilla calls "Intermediate configuration"
+  # Copied from https://mozilla.github.io/server-side-tls/ssl-config-generator/
+  ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+  ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA';
+  ssl_prefer_server_ciphers on;
 
-        # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
-        add_header Strict-Transport-Security max-age=15768000;
+  # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
+  add_header Strict-Transport-Security max-age=15768000;
 
-        # OCSP Stapling
-        # fetch OCSP records from URL in ssl_certificate and cache them
-        ssl_stapling on;
-        ssl_stapling_verify on;
+  # OCSP Stapling
+  # fetch OCSP records from URL in ssl_certificate and cache them
+  ssl_stapling on;
+  ssl_stapling_verify on;
 
-        location ^~ /.well-known/acme-challenge/ {
-          default_type  "text/plain";
-          root          /var/www/letsencrypt;
-        }
+  location ^~ /.well-known/acme-challenge/ {
+    default_type  "text/plain";
+    root          /var/www/letsencrypt;
+  }
 
 _EOF_
         mkdir -p /var/www/letsencrypt
@@ -153,11 +186,9 @@ _EOF_
   source $CUR_DIR/reverse_proxy.sh SERVER${j} ${j}
 
   cat >> ${configFile} <<_EOF_
-      # Load configuration files for the default server block.
-      include ${NGINX_DIRECTORY}/conf.d/server${j}/*.conf;
-
-    }
-
+  # Load configuration files for the default server block.
+  include ${NGINX_DIRECTORY}/conf.d/server${j}/*.conf;
+}
 _EOF_
   cat ${configFile}
 done

--- a/imagescripts/custom_server.sh
+++ b/imagescripts/custom_server.sh
@@ -115,6 +115,7 @@ _EOF_
 
   cat >> ${configFile} <<_EOF_
   server_name         ${NGINX_SERVER_NAME};
+
 _EOF_
 
   if [ -n "$NGINX_CERTIFICATE_DNAME" ] && [ "${NGINX_HTTPS_ENABLED}" = 'true' ]; then
@@ -128,16 +129,29 @@ _EOF_
   fi
 
   if [ ! -n "$NGINX_CERTIFICATE_DNAME" ] && [ "${NGINX_HTTPS_ENABLED}" = 'true' ]; then
-    cat >> ${configFile} <<_EOF_
+    if [ "${NGINX_LETSENCRYPT_CERTIFICATES}" = 'true' ]; then
+      cat >> ${configFile} <<_EOF_
+  ssl_certificate         ${NGINX_CERTIFICATE_TRUSTED};
+  ssl_certificate_key     ${NGINX_CERTIFICATE_KEY};
+_EOF_
+    else
+      cat >> ${configFile} <<_EOF_
   ssl_certificate         ${NGINX_CERTIFICATE_FILE};
   ssl_certificate_key     ${NGINX_CERTIFICATE_KEY};
 _EOF_
+    fi
   fi
 
   if [ -n "$NGINX_CERTIFICATE_TRUSTED" ]; then
-    cat >> ${configFile} <<_EOF_
+    if [ "${NGINX_LETSENCRYPT_CERTIFICATES}" = 'true' ]; then
+      cat >> ${configFile} <<_EOF_
+  ssl_trusted_certificate ${NGINX_CERTIFICATE_FILE};
+_EOF_
+    else
+      cat >> ${configFile} <<_EOF_
   ssl_trusted_certificate ${NGINX_CERTIFICATE_TRUSTED};
 _EOF_
+    fi
   fi
 
   if [ -n "$NGINX_CERTIFICATE_DNAME" ] && [ "${NGINX_HTTPS_ENABLED}" = 'true' ]; then

--- a/imagescripts/default_server.sh
+++ b/imagescripts/default_server.sh
@@ -2,25 +2,47 @@
 
 set -o errexit
 
+nginx_use_ipv6="false"
+nginx_http_port="80"
+
+if [ -n "${NGINX_USE_IPV6}" ]; then
+  nginx_use_ipv6=${NGINX_USE_IPV6}
+fi
+
+if [ -n "${NGINX_HTTP_PORT}" ]; then
+  nginx_http_port=${NGINX_HTTP_PORT}
+fi
+
 cat >> ${NGINX_DIRECTORY}/nginx.conf <<_EOF_
-    server {
-        listen       80 default_server;
-        listen       [::]:80 default_server;
-        server_name  _;
-        root         /usr/share/nginx/html;
+server {
+_EOF_
 
-        # Load configuration files for the default server block.
-        include ${NGINX_DIRECTORY}/default.d/*.conf;
+if [ "${nginx_use_ipv6}" = 'true' ]; then
+  cat >> ${NGINX_DIRECTORY}/nginx.conf <<_EOF_
+  listen       [::]:${nginx_http_port} default_server;
+_EOF_
+else
+  cat >> ${NGINX_DIRECTORY}/nginx.conf <<_EOF_
+  listen       ${nginx_http_port} default_server;
+_EOF_
+fi
 
-        location / {
-        }
+cat >> ${NGINX_DIRECTORY}/nginx.conf <<_EOF_
+  server_name  _;
+  root         /usr/share/nginx/html;
 
-        error_page 404 /404.html;
-            location = /40x.html {
-        }
+  # Load configuration files for the default server block.
+  include ${NGINX_DIRECTORY}/default.d/*.conf;
 
-        error_page 500 502 503 504 /50x.html;
-            location = /50x.html {
-        }
-    }
+  location / {
+  }
+
+  error_page 404 /404.html;
+    location = /40x.html {
+  }
+
+  error_page 500 502 503 504 /50x.html;
+    location = /50x.html {
+  }
+}
 _EOF_

--- a/imagescripts/port_redirect.sh
+++ b/imagescripts/port_redirect.sh
@@ -2,6 +2,12 @@
 
 set -o errexit
 
+nginx_use_ipv6="false"
+
+if [ -n "${NGINX_IPV6_ENABLED}" ]; then
+  nginx_use_ipv6=${NGINX_IPV6_ENABLED}
+fi
+
 NGINX_PORT_REDIRECT_PATTERN='https://$server_name$request_uri'
 
 PORT_REDIRECT_FILE=${NGINX_DIRECTORY}/conf.d/portRedirect.conf
@@ -25,12 +31,23 @@ do
 
   cat >> ${PORT_REDIRECT_FILE} <<_EOF_
 
-    server {
-       listen       80;
-       listen       [::]:80;
-       server_name  ${NGINX_SERVER_NAME};
-       return       301 ${NGINX_PORT_REDIRECT_PATTERN};
-    }
+  server {
+_EOF_
+
+  if [ "${nginx_use_ipv6}" = 'true' ]; then
+    cat >> ${PORT_REDIRECT_FILE} <<_EOF_
+      listen       [::]:80;
+_EOF_
+  else
+    cat >> ${PORT_REDIRECT_FILE} <<_EOF_
+      listen       80;
+_EOF_
+  fi
+
+  cat >> ${PORT_REDIRECT_FILE} <<_EOF_
+      server_name  ${NGINX_SERVER_NAME};
+      return       301 ${NGINX_PORT_REDIRECT_PATTERN};
+  }
 
 _EOF_
 done


### PR DESCRIPTION
- IPv6 disabled by default (needed to enable IPv6 on my Docker host just for NGINX..)
- use primary nameserver
- custom HTTP and HTTPS ports possible (default 80 & 443)
- Let's Encrypt stapling error fix (not sure if we get the same error with different certificates)