### PR TITLE
Debugging & access_log ${ACCESS_LOG} main; issue

### DIFF
--- a/imagescripts/create_config.sh
+++ b/imagescripts/create_config.sh
@@ -24,8 +24,17 @@ events {
 
 http {
   log_format  main  '${LOG_FORMAT}';
-
+_EOF_
+if [ "${DISABLE_ACCESS_LOG}" = 'true' ]; then
+  cat >> ${NGINX_DIRECTORY}/nginx.conf <<_EOF_
+  access_log ${ACCESS_LOG};
+_EOF_
+else
+  cat >> ${NGINX_DIRECTORY}/nginx.conf <<_EOF_
   access_log ${ACCESS_LOG} main;
+_EOF_
+fi
+cat >> ${NGINX_DIRECTORY}/nginx.conf <<_EOF_
 
   sendfile              on;
   tcp_nopush            on;

--- a/imagescripts/docker-entrypoint.sh
+++ b/imagescripts/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -o errexit
 
+[[ ${DEBUG} == true ]] && set -x
+
 # Setting environment variables
 readonly CUR_DIR=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
 


### PR DESCRIPTION
- added debug variable to docker-entrypoint.sh
- fixed configuration error when using DISABLE_ACCESS_LOG="true"